### PR TITLE
Disambiguate diary entry matching instead of guessing

### DIFF
--- a/src/myfitnesspal_mcp/diary.py
+++ b/src/myfitnesspal_mcp/diary.py
@@ -17,6 +17,15 @@ MEAL_INDEX = {"breakfast": "0", "lunch": "1", "dinner": "2", "snacks": "3", "sna
 
 MEALS = ("breakfast", "lunch", "dinner", "snacks")
 
+MEAL_ALIASES = {"snack": "snacks"}
+
+
+def _normalize_meal(meal: str | None) -> str | None:
+    if meal is None:
+        return None
+    lowered = meal.lower()
+    return MEAL_ALIASES.get(lowered, lowered)
+
 
 def api_headers(client, extra: dict | None = None) -> dict:
     headers = {
@@ -212,16 +221,14 @@ def diary_entries(doc) -> list[dict]:
     return entries
 
 
-def find_entry(entries: list[dict], query: str, meal: str | None) -> dict | None:
+def _meal_pool(entries: list[dict], meal: str | None) -> list[dict]:
+    target = _normalize_meal(meal)
+    return entries if target is None else [e for e in entries if e["meal"] == target]
+
+
+def find_entries(entries: list[dict], query: str, meal: str | None = None) -> list[dict]:
     needle = query.lower()
-    if meal is None:
-        pool = entries
-    else:
-        pool = [e for e in entries if e["meal"] == meal.lower()]
-    for entry in pool:
-        if needle in entry["name"].lower():
-            return entry
-    return None
+    return [e for e in _meal_pool(entries, meal) if needle in e["name"].lower()]
 
 
 def remove_entry(client, entry_id: str, token: str) -> None:
@@ -244,16 +251,38 @@ class NoMatchingEntry(RuntimeError):
     pass
 
 
+class AmbiguousEntry(RuntimeError):
+    def __init__(self, query: str, meal: str | None, day: date, candidates: list[dict]):
+        self.candidates = candidates
+        where = f" in {meal}" if meal else ""
+        options = "; ".join(f"{c['name']!r}" for c in candidates)
+        super().__init__(
+            f"'{query}'{where} on {day.isoformat()} matches multiple diary entries: "
+            f"{options}. Use a more specific query to pick one."
+        )
+
+
+def resolve_entry(entries: list[dict], query: str, meal: str | None, day: date) -> dict:
+    candidates = find_entries(entries, query, meal)
+    exact = [c for c in candidates if c["name"].lower() == query.lower()]
+    if len(exact) == 1:
+        return exact[0]
+    if len(candidates) == 1:
+        return candidates[0]
+    if candidates:
+        raise AmbiguousEntry(query, meal, day, candidates)
+    where = f" in {meal}" if meal else ""
+    pool = _meal_pool(entries, meal)
+    logged = "; ".join(f"{e['name']!r}" for e in pool) if pool else "(nothing logged)"
+    raise NoMatchingEntry(
+        f"no diary entry matching '{query}'{where} on {day.isoformat()}. "
+        f"Entries actually logged{where}: {logged}"
+    )
+
+
 def delete_food(client, day: date, query: str, meal: str | None = None) -> dict:
     doc, token = diary_page(client, day)
-    entry = find_entry(diary_entries(doc), query, meal)
-    if entry is None:
-        where = ""
-        if meal:
-            where = f" in {meal}"
-        raise NoMatchingEntry(
-            f"no diary entry matching '{query}'{where} on {day.isoformat()}"
-        )
+    entry = resolve_entry(diary_entries(doc), query, meal, day)
     remove_entry(client, entry["entry_id"], token)
     return {"removed": entry["name"], "meal": entry["meal"]}
 

--- a/src/myfitnesspal_mcp/diary.py
+++ b/src/myfitnesspal_mcp/diary.py
@@ -17,6 +17,17 @@ MEAL_INDEX = {"breakfast": "0", "lunch": "1", "dinner": "2", "snacks": "3", "sna
 
 MEALS = ("breakfast", "lunch", "dinner", "snacks")
 
+# Diary page headers always render the plural "Snacks"; normalize the singular
+# alias so meal filtering matches the same names MEAL_INDEX accepts for logging.
+MEAL_ALIASES = {"snack": "snacks"}
+
+
+def _normalize_meal(meal: str | None) -> str | None:
+    if meal is None:
+        return None
+    lowered = meal.lower()
+    return MEAL_ALIASES.get(lowered, lowered)
+
 
 def api_headers(client, extra: dict | None = None) -> dict:
     headers = {
@@ -212,16 +223,16 @@ def diary_entries(doc) -> list[dict]:
     return entries
 
 
-def find_entry(entries: list[dict], query: str, meal: str | None) -> dict | None:
+def _meal_pool(entries: list[dict], meal: str | None) -> list[dict]:
+    target = _normalize_meal(meal)
+    return entries if target is None else [e for e in entries if e["meal"] == target]
+
+
+def find_entries(entries: list[dict], query: str, meal: str | None = None) -> list[dict]:
+    """All diary entries whose name contains `query` (optionally scoped to `meal`),
+    in page order."""
     needle = query.lower()
-    if meal is None:
-        pool = entries
-    else:
-        pool = [e for e in entries if e["meal"] == meal.lower()]
-    for entry in pool:
-        if needle in entry["name"].lower():
-            return entry
-    return None
+    return [e for e in _meal_pool(entries, meal) if needle in e["name"].lower()]
 
 
 def remove_entry(client, entry_id: str, token: str) -> None:
@@ -244,16 +255,50 @@ class NoMatchingEntry(RuntimeError):
     pass
 
 
+class AmbiguousEntry(RuntimeError):
+    """Raised when `query` matches more than one diary entry and none is exact."""
+
+    def __init__(self, query: str, meal: str | None, day: date, candidates: list[dict]):
+        self.candidates = candidates
+        where = f" in {meal}" if meal else ""
+        options = "; ".join(f"{c['name']!r}" for c in candidates)
+        super().__init__(
+            f"'{query}'{where} on {day.isoformat()} matches multiple diary entries: "
+            f"{options}. Use a more specific query to pick one."
+        )
+
+
+def resolve_entry(entries: list[dict], query: str, meal: str | None, day: date) -> dict:
+    """Picks the diary entry `query` refers to, or raises with the available
+    options instead of silently guessing.
+
+    An exact (case-insensitive) name match wins outright even when other
+    entries also contain `query` as a substring. Otherwise a single substring
+    match is used; zero or multiple substring matches raise so the caller can
+    retry with a more specific query — surfacing what's actually logged, since
+    the text you'd expect to match (e.g. a cached display name) doesn't always
+    match what's on MFP's live diary page.
+    """
+    candidates = find_entries(entries, query, meal)
+    exact = [c for c in candidates if c["name"].lower() == query.lower()]
+    if len(exact) == 1:
+        return exact[0]
+    if len(candidates) == 1:
+        return candidates[0]
+    if candidates:
+        raise AmbiguousEntry(query, meal, day, candidates)
+    where = f" in {meal}" if meal else ""
+    pool = _meal_pool(entries, meal)
+    logged = "; ".join(f"{e['name']!r}" for e in pool) if pool else "(nothing logged)"
+    raise NoMatchingEntry(
+        f"no diary entry matching '{query}'{where} on {day.isoformat()}. "
+        f"Entries actually logged{where}: {logged}"
+    )
+
+
 def delete_food(client, day: date, query: str, meal: str | None = None) -> dict:
     doc, token = diary_page(client, day)
-    entry = find_entry(diary_entries(doc), query, meal)
-    if entry is None:
-        where = ""
-        if meal:
-            where = f" in {meal}"
-        raise NoMatchingEntry(
-            f"no diary entry matching '{query}'{where} on {day.isoformat()}"
-        )
+    entry = resolve_entry(diary_entries(doc), query, meal, day)
     remove_entry(client, entry["entry_id"], token)
     return {"removed": entry["name"], "meal": entry["meal"]}
 

--- a/src/myfitnesspal_mcp/server.py
+++ b/src/myfitnesspal_mcp/server.py
@@ -141,7 +141,11 @@ async def fitness_delete_food(
 ) -> dict:
     """Remove a food from the MyFitnessPal diary by name match.
 
-    query: text matched against logged entry names (e.g. "banana").
+    query: text matched against logged entry names (e.g. "banana"). If this
+    matches nothing, the error lists what's actually logged that day/meal — use
+    that to retry with a better query. If it matches more than one entry (and
+    none is an exact name match), the error lists the candidates; narrow `query`
+    to pick one.
     meal: optional breakfast|lunch|dinner|snacks to disambiguate duplicates.
     date: YYYY-MM-DD (default: today).
     """
@@ -166,7 +170,11 @@ async def fitness_modify_food(
 ) -> dict:
     """Replace a MyFitnessPal diary entry: deletes the match, then adds a food.
 
-    query: the existing entry to replace (name match) within `meal`.
+    query: the existing entry to replace (name match) within `meal`. If this
+    matches nothing, the error lists what's actually logged that day/meal — use
+    that to retry with a better query. If it matches more than one entry (and
+    none is an exact name match), the error lists the candidates; narrow `query`
+    to pick one.
     new_query: the food to add instead; omit to re-add `query` (e.g. to change
     quantity). meal: breakfast|lunch|dinner|snacks. date: YYYY-MM-DD (default: today).
     """

--- a/tests/test_diary.py
+++ b/tests/test_diary.py
@@ -96,14 +96,54 @@ def test_diary_entries_map_meals(client):
     ]
 
 
-def test_find_entry_scoped_by_meal():
+def test_find_entries_scoped_by_meal():
     entries = [
         {"entry_id": "1", "meal": "breakfast", "name": "Banana"},
         {"entry_id": "2", "meal": "lunch", "name": "Banana Bread"},
     ]
-    assert diary.find_entry(entries, "banana", None)["entry_id"] == "1"
-    assert diary.find_entry(entries, "banana", "lunch")["entry_id"] == "2"
-    assert diary.find_entry(entries, "kale", None) is None
+    assert [e["entry_id"] for e in diary.find_entries(entries, "banana")] == ["1", "2"]
+    assert [e["entry_id"] for e in diary.find_entries(entries, "banana", "lunch")] == ["2"]
+    assert diary.find_entries(entries, "kale") == []
+
+
+def test_find_entries_accepts_singular_snack_alias():
+    entries = [{"entry_id": "1", "meal": "snacks", "name": "Cherries"}]
+    assert [e["entry_id"] for e in diary.find_entries(entries, "cherries", "snack")] == ["1"]
+    assert [e["entry_id"] for e in diary.find_entries(entries, "cherries", "Snack")] == ["1"]
+
+
+def test_resolve_entry_returns_single_substring_match():
+    entries = [{"entry_id": "1", "meal": "breakfast", "name": "Banana"}]
+    entry = diary.resolve_entry(entries, "banana", None, TODAY)
+    assert entry["entry_id"] == "1"
+
+
+def test_resolve_entry_exact_match_wins_over_substring():
+    entries = [
+        {"entry_id": "1", "meal": "breakfast", "name": "Banana"},
+        {"entry_id": "2", "meal": "breakfast", "name": "Banana Bread"},
+    ]
+    entry = diary.resolve_entry(entries, "Banana", None, TODAY)
+    assert entry["entry_id"] == "1"
+
+
+def test_resolve_entry_raises_ambiguous_when_no_exact_match():
+    entries = [
+        {"entry_id": "1", "meal": "dinner", "name": "Chicken Salad"},
+        {"entry_id": "2", "meal": "dinner", "name": "Chicken Soup"},
+    ]
+    with pytest.raises(diary.AmbiguousEntry) as exc_info:
+        diary.resolve_entry(entries, "chicken", None, TODAY)
+    message = str(exc_info.value)
+    assert "Chicken Salad" in message
+    assert "Chicken Soup" in message
+    assert exc_info.value.candidates == entries
+
+
+def test_resolve_entry_no_match_lists_what_is_actually_logged():
+    entries = [{"entry_id": "1", "meal": "dinner", "name": "Rice"}]
+    with pytest.raises(diary.NoMatchingEntry, match="Rice"):
+        diary.resolve_entry(entries, "beef", "dinner", TODAY)
 
 
 def test_delete_food_removes_match(client):


### PR DESCRIPTION
find_entry silently returned the first substring match (or None), so an ambiguous query could quietly modify/delete the wrong diary entry, and a failed match gave no clue why. Replace it with find_entries (all matches) and resolve_entry, which picks an exact name match outright, accepts a lone substring match, and otherwise raises: NoMatchingEntry now lists what's actually logged in that meal/day, and a new AmbiguousEntry lists the conflicting candidates, so a caller can retry with a tighter query instead of getting a bare 404.

Also fixes the meal alias mismatch: singular "snack" is a valid alias for logging (MEAL_INDEX) but never matched the "snacks" header text diary entries are scoped by, so delete/modify with meal="snack" always failed to find anything.